### PR TITLE
RM-2 | Create an Employer migration and model

### DIFF
--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Employer extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'start_date',
+        'end_date',
+        'is_current_employer',
+        'is_remote_employer',
+        'my_location',
+        'employer_location',
+    ];
+}

--- a/database/migrations/2024_09_05_233035_create_employers_table.php
+++ b/database/migrations/2024_09_05_233035_create_employers_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('employers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->dateTime('start_date')->nullable();
+            $table->dateTime('end_date')->nullable();
+            $table->boolean('is_current_employer')->default(false);;
+            $table->boolean('is_remote_employer')->default(false);
+            $table->string('my_location')->nullable();
+            $table->string('employer_location')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('employers');
+    }
+};


### PR DESCRIPTION
# [RM-2] | Create an `Employer` migration and model
- Epic: [RM-11]

## Work
Create an `Employer` model and migration to store various employers. This should store the `name`, `start date`, `end date` and if it is the `current employer` as a minimum.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** the `employers` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `employer` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

[RM-2]: https://rheannemcintosh.atlassian.net/browse/RM-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ