### PR TITLE
RM-3 | Create a Role migration and model

### DIFF
--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -19,4 +19,9 @@ class Employer extends Model
         'my_location',
         'employer_location',
     ];
+
+    public function roles()
+    {
+        return $this->hasMany(Role::class);
+    }
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'employer_id',
+        'start_date',
+        'end_date',
+        'is_current_role',
+    ];
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -16,4 +16,9 @@ class Role extends Model
         'end_date',
         'is_current_role',
     ];
+    
+    public function employer()
+    {
+        return $this->belongsTo(Employer::class);
+    }
 }

--- a/database/migrations/2024_09_07_180637_create_roles_table.php
+++ b/database/migrations/2024_09_07_180637_create_roles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->foreignId('employer_id')->constrained();
+            $table->dateTime('start_date')->nullable();
+            $table->dateTime('end_date')->nullable();
+            $table->boolean('is_current_role')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};


### PR DESCRIPTION
# [RM-3] | Create a `Role` migration and model
- Epic: [RM-11]

## Work
Create a `Role` model and migration to store various roles. This should store the `title`, `start date`, `end date` and the `employer` it is connected to as a minimum.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** the `roles` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `role` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

### Acceptance Criteria 3
**WHEN** I attach roles to an employer
**AND** I view an employer
**THEN** I can view an employer with the attached roles.

[RM-3]: https://rheannemcintosh.atlassian.net/browse/RM-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ