### PR TITLE
RM-4 | Create a Responsibility migration and model

### DIFF
--- a/app/Models/Responsibility.php
+++ b/app/Models/Responsibility.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Responsibility extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'role_id',
+        'description',
+        'sort_order',
+    ];
+}

--- a/app/Models/Responsibility.php
+++ b/app/Models/Responsibility.php
@@ -14,4 +14,9 @@ class Responsibility extends Model
         'description',
         'sort_order',
     ];
+
+    public function role()
+    {
+        return $this->belongsTo(Role::class);
+    }
 }

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -16,9 +16,14 @@ class Role extends Model
         'end_date',
         'is_current_role',
     ];
-    
+
     public function employer()
     {
         return $this->belongsTo(Employer::class);
+    }
+
+    public function responsibilities()
+    {
+        return $this->hasMany(Responsibility::class);
     }
 }

--- a/database/migrations/2024_09_07_191949_create_responsibilities_table.php
+++ b/database/migrations/2024_09_07_191949_create_responsibilities_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('responsibilities', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('role_id')->constrained();
+            $table->text('description');
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('responsibilities');
+    }
+};


### PR DESCRIPTION
# [RM-4] | Create a `Responsibility` migration and model
- Epic: [RM-11]

## Work
Create a `Responsibility` model and migration to store various responsibilities. This should store the `role` it is connected to and its `description`.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** a `responsibilities` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `responsibility` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

### Acceptance Criteria 3
**WHEN** I attach responsibilities to a role
**AND** I view an employer
**THEN** I can view an employer with the attached roles and responsibilities.

[RM-4]: https://rheannemcintosh.atlassian.net/browse/RM-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ