### PR TITLE
RM-5 | Fix bug with flashing CSS on page load

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -12,7 +12,7 @@
 
         <!-- Scripts -->
         @routes
-        @vite(['resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
+        @vite(['resources/css/app.css', 'resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
         @inertiaHead
     </head>
     <body class="font-sans antialiased">

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,7 @@ import vue from '@vitejs/plugin-vue';
 export default defineConfig({
     plugins: [
         laravel({
-            input: 'resources/js/app.js',
+            input: ['resources/css/app.css', 'resources/js/app.js'],
             ssr: 'resources/js/ssr.js',
             refresh: true,
         }),


### PR DESCRIPTION
# [RM-5] | Fix bug with flashing CSS on page load

- Epic: [RM-12]

## Work
When reloading a page, there is a flash of unstyled content, which can be annoying when testing, and doesn’t look great on production.

To fix this, the following Laracasts thread was found: https://laracasts.com/discuss/channels/inertia/inertiajs-ssr-flash-of-unstyled-content.

## Testing
- Run `npm run dev`

### Acceptance Criteria 1
**WHEN** I reload a page
**THEN** there is no flash of unstyled content.

[RM-5]: https://rheannemcintosh.atlassian.net/browse/RM-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-12]: https://rheannemcintosh.atlassian.net/browse/RM-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ