### PR TITLE
RM-7 | Create an Employer component

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Employer;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class EmployerController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -13,7 +13,11 @@ class EmployerController extends Controller
      */
     public function index()
     {
-        //
+        $employers = Employer::with('roles.responsibilities')->get();
+
+        return Inertia::render('Employers/Index', [
+            'employers' => $employers,
+        ]);
     }
 
     /**

--- a/app/Models/Employer.php
+++ b/app/Models/Employer.php
@@ -18,6 +18,7 @@ class Employer extends Model
         'is_remote_employer',
         'my_location',
         'employer_location',
+        'show_on_cv',
     ];
 
     public function roles()

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -15,6 +15,7 @@ class Role extends Model
         'start_date',
         'end_date',
         'is_current_role',
+        'show_on_cv',
     ];
 
     public function employer()

--- a/database/migrations/2024_09_05_233035_create_employers_table.php
+++ b/database/migrations/2024_09_05_233035_create_employers_table.php
@@ -21,6 +21,8 @@ return new class extends Migration
             $table->boolean('is_remote_employer')->default(false);
             $table->string('my_location')->nullable();
             $table->string('employer_location')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->boolean('show_on_cv')->default(true);
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_09_07_180637_create_roles_table.php
+++ b/database/migrations/2024_09_07_180637_create_roles_table.php
@@ -19,6 +19,8 @@ return new class extends Migration
             $table->dateTime('start_date')->nullable();
             $table->dateTime('end_date')->nullable();
             $table->boolean('is_current_role')->default(false);
+            $table->integer('sort_order')->default(0);
+            $table->boolean('show_on_cv')->default(true);
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_09_07_191949_create_responsibilities_table.php
+++ b/database/migrations/2024_09_07_191949_create_responsibilities_table.php
@@ -16,6 +16,7 @@ return new class extends Migration
             $table->foreignId('role_id')->constrained();
             $table->text('description');
             $table->integer('sort_order')->default(0);
+            $table->boolean('show_on_cv')->default(true);
             $table->timestamps();
         });
     }

--- a/resources/js/Components/CVHeading.vue
+++ b/resources/js/Components/CVHeading.vue
@@ -1,0 +1,24 @@
+<script setup>
+    const props = defineProps({
+        title: String,
+        icon: String,
+    });
+
+</script>
+
+<template>
+    <dv class="flex items-center text-green-700 ">
+            <span class="material-symbols-rounded text-4xl">
+                {{ icon }}
+            </span>
+        <h1 class="pl-2 font-bold text-4xl">
+            {{ title }}
+        </h1>
+    </dv>
+
+
+</template>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/Employers/Index.vue
+++ b/resources/js/Pages/Employers/Index.vue
@@ -1,0 +1,151 @@
+<script setup>
+
+    // Import Statements
+    import { ref, onMounted } from 'vue';
+    import CVHeading from '@/Components/CVHeading.vue';
+
+
+    // Define a reactive variable to store which employers are open
+    const openEmployers = ref([]);
+
+    // Define the props for the component
+    const props = defineProps({
+        employers: Array,
+    });
+
+    /**
+     * Toggle the dropdown state of an employer
+     *
+     * @param employerId The ID of the employer to toggle
+     */
+    function toggleOpen(employerId) {
+        if (openEmployers.value.includes(employerId)) {
+            openEmployers.value = openEmployers.value.filter(openEmployerId => openEmployerId !== employerId)
+        } else {
+            openEmployers.value.push(employerId);
+        }
+    }
+
+    /**
+     * Format a date to a human-readable format (e.g. MAR 2022)
+     *
+     * @param date The date to format
+     * @returns {string} The formatted date
+     */
+    const formatDate = (date) => {
+        return new Date(date).toLocaleDateString('en-UK', { year: 'numeric', month: 'short' });
+    }
+
+    /**
+     * Check if an employer has responsibilities attached
+     *
+     * @param roles The roles to check
+     * @returns {boolean} Whether the employer has responsibilities
+     */
+    const hasResponsibilities = (roles) => {
+        return roles.some(role => role.responsibilities && role.responsibilities.length > 0);
+    }
+
+    // Run this code when the component is mounted
+    onMounted(() => {
+        // console.log(props.employers);
+
+        props.employers.forEach((employer) => {
+            if (employer.is_default_open) {
+                openEmployers.value.push(employer.id);
+            }
+        });
+    });
+
+</script>
+
+<template>
+
+    <!-- Experience Card -->
+    <div class="bg-white rounded-md shadow-2xl p-8">
+
+        <!-- Experience Heading -->
+        <CVHeading title="Experience" icon="work" />
+
+        <!-- Experience Content -->
+        <div class="mt-4">
+
+            <!-- Loop through each employer -->
+            <div v-for="(employer) in employers" :key="employer.id" class="mb-2">
+
+                <!-- Check if the employer has a description or responsibilities -->
+                <div v-if="employer.description || hasResponsibilities(employer.roles)">
+
+                    <!-- Employer Dropdown Button -->
+                    <button
+                        @click="toggleOpen(employer.id)"
+                        class="flex justify-between items-center bg-green-700 text-white px-2 py-1 rounded-sm mb-1 w-full"
+                    >
+
+                        <!-- Employer Name and Role -->
+                        <div class="flex items-center">
+                            <h3 v-if="employer.roles.length === 1" class="text-lg font-bold uppercase">
+                                {{ employer.roles.length === 1 ? employer.roles[0].title : 'Various Roles,' }},
+                            </h3>
+                            <h4 id="name" class="text-lg pl-2">{{ employer.name }}</h4>
+                        </div>
+
+                        <!-- Employment Dates & Dropdown Toggle-->
+                        <div id="dates" class="text-xs text-right font-bold  font-mono uppercase flex items-center">
+
+                            <!-- Dates -->
+                            <span>
+                                {{ formatDate(employer.start_date) }} -
+                                {{ employer.is_current_employer ? 'Present' : formatDate(employer.end_date) }}
+                            </span>
+
+                            <!-- Dropdown Toggle -->
+                            <span :class="{'rotate-180': openEmployers.includes(employer.id)}" class=" material-symbols-rounded ml-2 transform transition-transform duration-300 inline-block">
+                                arrow_drop_down
+                            </span>
+
+                        </div>
+
+                    </button>
+
+                    <!-- Employer Description and Responsibilities -->
+                    <div
+                        v-if="openEmployers.includes(employer.id)"
+                        class="transition-all duration-300 ease-in-out transform mb-4"
+                        :class="{ 'opacity-100 max-h-96': openEmployers.includes(employer.id), 'opacity-0 max-h-0': !openEmployers.includes(employer.id) }"
+                    >
+                        <!-- Employer Description -->
+                        <p class="mb-2 text-justify">{{ employer.description}}</p>
+
+                        <!-- Employer Responsibilities -->
+                        <div v-for="role in employer.roles" :key="role.id">
+                            <div v-if="role.responsibilities.length > 0">
+
+                                <!-- Role Title -->
+                                <div v-if="employer.roles.length > 1" class="text-green-700 font-bold">
+                                    {{ role.title }}
+                                </div>
+
+                                <!-- Responsibilities List -->
+                                <div v-if="role.responsibilities.length > 0">
+                                    <ul class="pl-4 list-disc text-sm ">
+                                        <li v-for="responsibility in role.responsibilities" :key="responsibility.id" class="text-justify">
+                                            {{ responsibility.description }}
+                                        </li>
+                                    </ul>
+                                </div>
+
+                            </div>
+                        </div>
+
+                    </div>
+
+                </div>
+
+            </div>
+
+        </div>
+
+    </div>
+
+</template>

--- a/resources/js/Pages/Employers/Index.vue
+++ b/resources/js/Pages/Employers/Index.vue
@@ -84,8 +84,8 @@
 
                         <!-- Employer Name and Role -->
                         <div class="flex items-center">
-                            <h3 v-if="employer.roles.length === 1" class="text-lg font-bold uppercase">
-                                {{ employer.roles.length === 1 ? employer.roles[0].title : 'Various Roles,' }},
+                            <h3 class="text-lg font-bold uppercase">
+                                {{ employer.roles.length === 1 ? employer.roles[0].title :  "Various Roles" }},
                             </h3>
                             <h4 id="name" class="text-lg pl-2">{{ employer.name }}</h4>
                         </div>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -10,13 +10,14 @@
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@24,500,1,0" />
         <!-- Scripts -->
         @routes
         @vite(['resources/css/app.css', 'resources/js/app.js', "resources/js/Pages/{$page['component']}.vue"])
         @inertiaHead
     </head>
-    <body class="font-sans antialiased">
-        <div class="flex py-4  border-b-4 border-green-700">
+    <body class="font-sans antialiased bg-gray-50">
+        <div class="flex py-4 border-b-4 border-green-700">
             <div class="m-auto justify-center items-center text-green-700">
                 <h1 class="text-7xl font-bold text-center">Rheanne McIntosh</h1>
                 <h2 class="text-4xl text-center">Lead Software Engineer</h2>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Http\Controllers\EmployerController;
 use App\Http\Controllers\ProfileController;
+use App\Models\Employer;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -11,6 +13,7 @@ Route::get('/', function () {
         'canRegister' => Route::has('register'),
         'laravelVersion' => Application::VERSION,
         'phpVersion' => PHP_VERSION,
+//        'employers' => Employer::all(),
     ]);
 });
 
@@ -22,6 +25,11 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+});
+
+
+Route::prefix('cv')->group(function () {
+    Route::get('/employers', [EmployerController::class, 'index'])->name('employers.index');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
# [RM-7] | Create an Employer CV Component

- Epic: [RM-13]

## Work
Create an employer component which displays various employers, roles, and responsibilities.

## Testing
- Run `php artisan migrate:fresh`
- Run `php artisan db:seed` (if you have seeders to test with)
- Run `npm run dev`
- Visit `rheanne-mcintosh-portfolio.test/cv/employers`

### Acceptance Criteria 1
**WHEN** I visit the employers URL
**AND** I have populated the employers, roles and responsibilities
**THEN** I can see an interactive list of employers.

### Acceptance Criteria 2
**WHEN** I visit the employers URL
**AND** I have an employer with no roles or responsibilities attached
**THEN** I cannot see this on the list of employers.

[RM-7]: https://rheannemcintosh.atlassian.net/browse/RM-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-13]: https://rheannemcintosh.atlassian.net/browse/RM-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ