### PR TITLE
RM-8 | Create an Education migration and model

### DIFF
--- a/app/Models/Education.php
+++ b/app/Models/Education.php
@@ -18,7 +18,6 @@ class Education extends Model
         'is_remote_education',
         'my_location',
         'education_location',
-        'show_on_cv',
         'sort_order',
         'show_on_cv',
     ];

--- a/app/Models/Education.php
+++ b/app/Models/Education.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Education extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'institution',
+        'description',
+        'start_date',
+        'end_date',
+        'is_current_education',
+        'is_remote_education',
+        'my_location',
+        'education_location',
+        'show_on_cv',
+        'sort_order',
+        'show_on_cv',
+    ];
+}

--- a/database/migrations/2024_09_10_210233_create_education_table.php
+++ b/database/migrations/2024_09_10_210233_create_education_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('education', function (Blueprint $table) {
+            $table->id();
+            $table->string('institution');
+            $table->text('description')->nullable();
+            $table->dateTime('start_date')->nullable();
+            $table->dateTime('end_date')->nullable();
+            $table->boolean('is_current_education')->default(false);
+            $table->boolean('is_remote_education')->default(false);
+            $table->string('my_location')->nullable();
+            $table->string('education_location')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->boolean('show_on_cv')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('education');
+    }
+};


### PR DESCRIPTION
# [RM-8] | Create an `Education` migration and model

- Epic: [RM-11]

## Work
Create an `Education` model and migration to store institutions such as universities and schools. This should store the `name`, `start_date` and `end_date` as a minimum.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** the `education` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `education` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

[RM-8]: https://rheannemcintosh.atlassian.net/browse/RM-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ