### PR TITLE
RM-10 | Create a Degree migration and model

### DIFF
--- a/app/Models/Degree.php
+++ b/app/Models/Degree.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Degree extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'education_id',
+        'grade',
+        'start_date',
+        'end_date',
+        'is_current_degree',
+        'show_on_cv',
+    ];
+}

--- a/database/migrations/2024_09_12_225645_create_degrees_table.php
+++ b/database/migrations/2024_09_12_225645_create_degrees_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('degrees', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->foreignId('education_id')->constrained();
+            $table->string('grade')->nullable();
+            $table->dateTime('start_date')->nullable();
+            $table->dateTime('end_date')->nullable();
+            $table->boolean('is_current_degree')->default(false);
+            $table->boolean('show_on_cv')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('degrees');
+    }
+};


### PR DESCRIPTION
# [RM-10] | Create a `Degree` migration and model
- Epic: [RM-11]

## Work
Create a `Degree` model and migration to store undergraduate and postgraduate degrees. This should store the `title`, `grade` and the `institution` its connected to.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** a `degrees` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `degree` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

### Acceptance Criteria 3
**WHEN** I attach degrees to an education institution
**AND** I view an education institution
**THEN** I can view an education institution with the attached degrees

[RM-10]: https://rheannemcintosh.atlassian.net/browse/RM-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ