### PR TITLE
RM-19 | Fix div issue with the CV heading component

### DIFF
--- a/resources/js/Components/CVHeading.vue
+++ b/resources/js/Components/CVHeading.vue
@@ -7,14 +7,14 @@
 </script>
 
 <template>
-    <dv class="flex items-center text-green-700 ">
+    <div class="flex items-center text-green-700 ">
             <span class="material-symbols-rounded text-4xl">
                 {{ icon }}
             </span>
         <h1 class="pl-2 font-bold text-4xl">
             {{ title }}
         </h1>
-    </dv>
+    </div>
 
 
 </template>


### PR DESCRIPTION
# [RM-19] | Fix div issue with the CV heading component

## Work
Updates the CV Heading to fix the wrongly defined div component.

## Testing
- Run `npm run dev`

### Acceptance Criteria 1
**WHEN** I view the application
**THEN** the cv heading component still works.

[RM-19]: https://rheannemcintosh.atlassian.net/browse/RM-19?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ