### PR TITLE
RM-16 | Create an Education Component

### DIFF
--- a/app/Http/Controllers/EducationController.php
+++ b/app/Http/Controllers/EducationController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Education;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class EducationController extends Controller
+{
+    public function index()
+    {
+        $education = Education::with('degrees')->get();
+
+        return Inertia::render('Education/Index', [
+            'education' => $education,
+        ]);
+    }
+}

--- a/app/Models/Education.php
+++ b/app/Models/Education.php
@@ -21,4 +21,9 @@ class Education extends Model
         'sort_order',
         'show_on_cv',
     ];
+
+    public function degrees()
+    {
+        return $this->hasOne(Degree::class);
+    }
 }

--- a/resources/js/Pages/Education/Index.vue
+++ b/resources/js/Pages/Education/Index.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+
+import { ref, onMounted } from 'vue';
+
+import CVHeading from "@/Components/CVHeading.vue";
+import { Education } from '@/types/Education';
+
+// Define the props for the component
+const props = defineProps<{
+    education: Education[];
+}>();
+
+const openEducation = ref<number[]>([]);
+
+/**
+ * Toggle the dropdown state of an employer
+ *
+ * @param educationId The ID of the employer to toggle
+ */
+function toggleOpen(educationId: number): void {
+    if (openEducation.value.includes(educationId)) {
+        openEducation.value = openEducation.value.filter(openEducationId => openEducationId !== educationId);
+    } else {
+        openEducation.value.push(educationId);
+    }
+}
+
+/**
+ * Format a date to a human-readable format (e.g. MAR 2022)
+ *
+ * @param date The date to format
+ * @returns {string} The formatted date
+ */
+const formatDate = (date: string): string => {
+    console.log(date)
+    return new Date(date).toLocaleDateString('en-UK', { year: 'numeric', month: 'short' });
+}
+
+// Run this code when the component is mounted
+onMounted((): void => {
+    props.education.forEach((institution) => {
+        if (institution.is_default_open) {
+            openEducation.value.push(institution.id);
+        }
+    });
+});
+
+</script>
+
+<template>
+    <!-- Experience Card -->
+    <div class="bg-white rounded-md shadow-2xl p-8">
+        <!-- Experience Heading -->
+        <CVHeading title="Education" icon="school" />
+
+        <!-- Experience Content -->
+        <div class="mt-4">
+            <!-- Loop through each education -->
+            <div v-for="(institution) in education" :key="institution.id" class="mb-2">
+
+                <!-- Check if the employer has a description or responsibilities -->
+                <div>
+                    <!-- Employer Dropdown Button -->
+                    <button
+                        @click="toggleOpen(institution.id)"
+                        class="flex justify-between items-center bg-green-700 text-white px-2 py-1 rounded-sm mb-1 w-full"
+                    >
+                        <!-- Employer Name and Role -->
+                        <div class="flex items-center">
+                            <h3 class="text-lg font-bold uppercase">
+
+                                {{ institution.degrees?.title }},
+                            </h3>
+                            <h4 id="name" class="text-lg pl-2">{{ institution.institution }}</h4>
+                        </div>
+
+                        <!-- Employment Dates & Dropdown Toggle -->
+                        <div id="dates" class="text-xs text-right font-bold font-mono uppercase flex items-center">
+                            <!-- Dates -->
+                            <span>
+                                {{ formatDate(institution.start_date) }} -
+                                {{ institution.is_current_education ? 'Present' : formatDate(institution.end_date) }}
+                            </span>
+
+                            <!-- Dropdown Toggle -->
+                            <span
+                                :class="{'rotate-180': openEducation.includes(institution.id)}"
+                                class="material-symbols-rounded ml-2 transform transition-transform duration-300 inline-block"
+                            >
+                                arrow_drop_down
+                            </span>
+                        </div>
+                    </button>
+
+                    <!-- Employer Description and Responsibilities -->
+                    <div
+                        v-if="openEducation.includes(institution.id)"
+                        class="transition-all duration-300 ease-in-out transform mb-4"
+                        :class="{ 'opacity-100 max-h-96': openEducation.includes(institution.id), 'opacity-0 max-h-0': !openEducation.includes(institution.id) }"
+                    >
+                        <!-- Employer Description -->
+                        <p class="mb-2 text-justify">{{ institution.description }}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/types/Degree.ts
+++ b/resources/js/types/Degree.ts
@@ -1,0 +1,6 @@
+
+
+export interface Degree {
+    id: number;
+    title: string;
+}

--- a/resources/js/types/Education.ts
+++ b/resources/js/types/Education.ts
@@ -1,0 +1,16 @@
+import { Degree } from './Degree';
+
+export interface Education {
+    id: number;
+    institution: string;
+    start_date: string;
+    end_date?: string;  // Optional end_date
+    is_current_education: boolean;
+    degree?: Degree;
+    // start_date: string;
+    // end_date?: string;  // Optional end_date
+    // is_current_employer: boolean;
+    description?: string;  // Optional description
+    is_default_open: boolean;
+    // roles: Role[];
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\EducationController;
 use App\Http\Controllers\EmployerController;
 use App\Http\Controllers\ProfileController;
 use App\Models\Employer;
@@ -29,6 +30,7 @@ Route::middleware('auth')->group(function () {
 
 Route::prefix('cv')->group(function () {
     Route::get('/employers', [EmployerController::class, 'index'])->name('employers.index');
+    Route::get('/education', [EducationController::class, 'index'])->name('education.index');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
# [RM-16] | Create an Education CV Component

- Epic: [RM-13]

## Work
Create an education component which displays various education institutions and degrees. This should be done in Vue, and only display education institutions if there are degrees attached.

## Testing
- Run `php artisan migrate:fresh`
- Run `php artisan db:seed` (if you have seeders to test with)
- Run `npm run dev`
- Visit `rheanne-mcintosh-portfolio.test/cv/education`

### Acceptance Criteria 1
**WHEN** I visit the education URL
**AND** I have populated the education institutions and degrees
**THEN** I can see an interactive list of education institutions

### Acceptance Criteria 2
**WHEN** I visit the education URL
**AND** I have an education institution with no degrees attached
**THEN** I cannot see this on the list of education institutions

[RM-13]: https://rheannemcintosh.atlassian.net/browse/RM-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-16]: https://rheannemcintosh.atlassian.net/browse/RM-16?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ