### PR TITLE
RM-24 | Create Skill Categories Migration and Model

### DIFF
--- a/app/Models/SkillCategory.php
+++ b/app/Models/SkillCategory.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class SkillCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'category',
+        'description',
+        'pill_class',
+    ];
+}

--- a/database/migrations/2024_09_28_011754_create_skill_categories_table.php
+++ b/database/migrations/2024_09_28_011754_create_skill_categories_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('skill_categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('category');
+            $table->text('description');
+            $table->string('pill_class');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('skill_categories');
+    }
+};


### PR DESCRIPTION
# [RM-24] | Create a `Skill Category` migration and model
- Epic: [RM-11]

## Work
Create a `Skill Category` model and migration to store the category of skills, i.e. programming languages, frameworks etc.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** a `skill_categories` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `Skill Category` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

[RM-24]: https://rheannemcintosh.atlassian.net/browse/RM-24?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ