### PR TITLE
RM-25 | Create a Skill Migration and Model

### DIFF
--- a/app/Models/Skill.php
+++ b/app/Models/Skill.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Skill extends Model
+{
+    use HasFactory;
+}

--- a/database/migrations/2024_09_28_012956_create_skills_table.php
+++ b/database/migrations/2024_09_28_012956_create_skills_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('skills', function (Blueprint $table) {
+            $table->id();
+            $table->string('skill');
+            $table->foreignId('skill_category_id')->constrained();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('skills');
+    }
+};


### PR DESCRIPTION
# [RM-25] | Create a `Skill` migration and model
- Epic: [RM-11]

## Work
Create a `Skill` model and migration to store various skills. This should link to the skill categories model as the parent.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1
**WHEN** I have ran the migration
**THEN** a skill table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the skill model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

[RM-25]: https://rheannemcintosh.atlassian.net/browse/RM-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ