### PR TITLE
RM-26 | Update the degrees migration and Education component to handle the institutions and degree as one

### DIFF
--- a/app/Http/Controllers/CVController.php
+++ b/app/Http/Controllers/CVController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Degree;
 use App\Models\Education;
 use App\Models\Employer;
 use Inertia\Inertia;
@@ -16,7 +17,7 @@ class CVController extends Controller
     public function index()
     {
         return Inertia::render('CV/Index', [
-            'education' => Education::with('degrees')->get(),
+            'degrees'   => Degree::orderBy('sort_order', 'DESC')->get(),
             'employers' => $this->getEmployers(),
         ]);
     }

--- a/app/Http/Controllers/CVController.php
+++ b/app/Http/Controllers/CVController.php
@@ -17,7 +17,7 @@ class CVController extends Controller
     public function index()
     {
         return Inertia::render('CV/Index', [
-            'degrees'   => Degree::orderBy('sort_order', 'DESC')->get(),
+            'degrees'   => Degree::where('show_on_cv', true)->orderBy('sort_order', 'DESC')->get(),
             'employers' => $this->getEmployers(),
         ]);
     }

--- a/database/migrations/2024_09_12_225645_create_degrees_table.php
+++ b/database/migrations/2024_09_12_225645_create_degrees_table.php
@@ -14,13 +14,20 @@ return new class extends Migration
         Schema::create('degrees', function (Blueprint $table) {
             $table->id();
             $table->string('title');
+            $table->string('short_title')->nullable();
+            $table->string('type');
+            $table->string('abbreviation');
             $table->text('description')->nullable();
-            $table->foreignId('education_id')->constrained();
             $table->string('grade')->nullable();
             $table->dateTime('start_date')->nullable();
             $table->dateTime('end_date')->nullable();
             $table->boolean('is_current_degree')->default(false);
             $table->boolean('show_on_cv')->default(true);
+            $table->integer('sort_order')->default(0);
+            $table->string('university');
+            $table->boolean('is_remote_university')->default(false);
+            $table->string('my_location')->nullable();
+            $table->string('education_location');
             $table->timestamps();
         });
     }

--- a/resources/js/Pages/CV/Index.vue
+++ b/resources/js/Pages/CV/Index.vue
@@ -6,7 +6,7 @@ import Education from "@/Pages/Education/Index.vue";
 import Employers from "@/Pages/Employers/Index.vue";
 
 const props = defineProps<{
-    education: Education[];
+    degrees: Degree[];
     employers: Employer[];
 }>();
 
@@ -27,7 +27,7 @@ const handlePillClick = (pillName: string) => {
 
     <div class="content">
         <Employers v-if="selectedPill === 'All' || selectedPill === 'Employers'" :employers="props.employers" />
-        <Education v-if="selectedPill === 'All' || selectedPill === 'Education'" :education="props.education" />
+        <Education v-if="selectedPill === 'All' || selectedPill === 'Education'" :degrees="props.degrees" />
     </div>
 </template>
 

--- a/resources/js/Pages/Education/Index.vue
+++ b/resources/js/Pages/Education/Index.vue
@@ -3,25 +3,25 @@
 import { ref, onMounted } from 'vue';
 
 import CVHeading from "@/Components/CVHeading.vue";
-import { Education } from '@/types/Education';
+import { Degree } from '@/types/Degree';
 
 // Define the props for the component
 const props = defineProps<{
-    education: Education[];
+    degrees: Degree[];
 }>();
 
-const openEducation = ref<number[]>([]);
+const openDegree = ref<number[]>([]);
 
 /**
  * Toggle the dropdown state of an employer
  *
  * @param educationId The ID of the employer to toggle
  */
-function toggleOpen(educationId: number): void {
-    if (openEducation.value.includes(educationId)) {
-        openEducation.value = openEducation.value.filter(openEducationId => openEducationId !== educationId);
+function toggleOpen(degreeId: number): void {
+    if (openDegree.value.includes(degreeId)) {
+        openDegree.value = openDegree.value.filter(openDegreeId => openDegreeId !== degreeId);
     } else {
-        openEducation.value.push(educationId);
+        openDegree.value.push(degreeId);
     }
 }
 
@@ -38,9 +38,9 @@ const formatDate = (date: string): string => {
 
 // Run this code when the component is mounted
 onMounted((): void => {
-    props.education.forEach((institution) => {
-        if (institution.is_default_open) {
-            openEducation.value.push(institution.id);
+    props.degrees.forEach((degree) => {
+        if (degree.is_default_open) {
+            openDegree.value.push(degree.id);
         }
     });
 });
@@ -51,40 +51,39 @@ onMounted((): void => {
     <!-- Experience Card -->
     <div class="bg-white rounded-md shadow-2xl p-8 mb-8">
         <!-- Experience Heading -->
-        <CVHeading title="Education" icon="school" />
+        <CVHeading title="University Education" icon="school" />
 
         <!-- Experience Content -->
         <div class="mt-4">
             <!-- Loop through each education -->
-            <div v-for="(institution) in education" :key="institution.id" class="mb-2">
+            <div v-for="(degree) in degrees" :key="degree.id" class="mb-2">
 
                 <!-- Check if the employer has a description or responsibilities -->
                 <div>
                     <!-- Employer Dropdown Button -->
                     <button
-                        @click="toggleOpen(institution.id)"
+                        @click="toggleOpen(degree.id)"
                         class="flex justify-between items-center bg-green-700 text-white px-2 py-1 rounded-sm mb-1 w-full"
                     >
                         <!-- Employer Name and Role -->
                         <div class="flex items-center">
                             <h3 class="text-lg font-bold uppercase">
-
-                                {{ institution.degrees?.title }},
+                                {{ degree.title }},
                             </h3>
-                            <h4 id="name" class="text-lg pl-2">{{ institution.institution }}</h4>
+                            <h4 id="name" class="text-lg pl-2">{{ degree.university }}</h4>
                         </div>
 
                         <!-- Employment Dates & Dropdown Toggle -->
                         <div id="dates" class="text-xs text-right font-bold font-mono uppercase flex items-center">
                             <!-- Dates -->
                             <span>
-                                {{ formatDate(institution.start_date) }} -
-                                {{ institution.is_current_education ? 'Present' : formatDate(institution.end_date) }}
+                                {{ formatDate(degree.start_date) }} -
+                                {{ degree.is_current_degree ? 'Present' : formatDate(degree.end_date) }}
                             </span>
 
                             <!-- Dropdown Toggle -->
                             <span
-                                :class="{'rotate-180': openEducation.includes(institution.id)}"
+                                :class="{'rotate-180': openDegree.includes(degree.id)}"
                                 class="material-symbols-rounded ml-2 transform transition-transform duration-300 inline-block"
                             >
                                 arrow_drop_down
@@ -94,12 +93,12 @@ onMounted((): void => {
 
                     <!-- Employer Description and Responsibilities -->
                     <div
-                        v-if="openEducation.includes(institution.id)"
+                        v-if="openDegree.includes(degree.id)"
                         class="transition-all duration-300 ease-in-out transform mb-4"
-                        :class="{ 'opacity-100 max-h-96': openEducation.includes(institution.id), 'opacity-0 max-h-0': !openEducation.includes(institution.id) }"
+                        :class="{ 'opacity-100 max-h-96': openDegree.includes(degree.id), 'opacity-0 max-h-0': !openDegree.includes(degree.id) }"
                     >
                         <!-- Employer Description -->
-                        <p class="mb-2 text-justify">{{ institution.description }}</p>
+                        <p class="mb-2 text-justify">{{ degree.description }}</p>
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Education/Index.vue
+++ b/resources/js/Pages/Education/Index.vue
@@ -68,7 +68,8 @@ onMounted((): void => {
                         <!-- Employer Name and Role -->
                         <div class="flex items-center">
                             <h3 class="text-lg font-bold uppercase">
-                                {{ degree.title }},
+                                {{ degree.abbreviation }}
+                                {{ degree.short_title ? degree.short_title : degree.title }},
                             </h3>
                             <h4 id="name" class="text-lg pl-2">{{ degree.university }}</h4>
                         </div>


### PR DESCRIPTION
# [RM-26] | Update the degrees migration and Education component to handle the institutions and degree as one
- Epic: [RM-13]

## Work
We had degrees and education institutions as two separate models. However, it’s unlikely we’d do both degrees at the same university, and a education institution is not necessarily suitable for school qualifications.

This story should add the necessary education institution fields to the degrees table. The education Vue component will also need to be updated.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have rerun the migration
**THEN** I can see the new columns in the database

### Acceptance Criteria 2
**WHEN** I create an instance of the `page` model
**AND** I populate all of the fields
**THEN** a row is populated in the database

### Acceptance Criteria 3
**WHEN** I open the CV Education page
**THEN** the page works the same as before


[RM-26]: https://rheannemcintosh.atlassian.net/browse/RM-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-13]: https://rheannemcintosh.atlassian.net/browse/RM-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ