### PR TITLE
RM-28 | Seed the skills and skill categories tables

### DIFF
--- a/database/migrations/2024_09_28_011754_create_skill_categories_table.php
+++ b/database/migrations/2024_09_28_011754_create_skill_categories_table.php
@@ -14,8 +14,9 @@ return new class extends Migration
         Schema::create('skill_categories', function (Blueprint $table) {
             $table->id();
             $table->string('category');
-            $table->text('description');
-            $table->string('pill_class');
+            $table->text('description')->nullable();
+            $table->integer('sort_order')->nullable();
+            $table->string('pill_class')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_09_28_012956_create_skills_table.php
+++ b/database/migrations/2024_09_28_012956_create_skills_table.php
@@ -14,7 +14,10 @@ return new class extends Migration
         Schema::create('skills', function (Blueprint $table) {
             $table->id();
             $table->string('skill');
-            $table->foreignId('skill_category_id')->constrained();
+            $table->enum('type', ['Primary', 'Secondary', 'Tertiary'])->nullable();
+            $table->foreignId('skill_category_id')->nullable()->constrained();
+            $table->integer('sort_order')->nullable();
+            $table->boolean('show_on_homepage')->default(false);
             $table->timestamps();
         });
     }

--- a/database/seeders/SkillCategorySeeder.php
+++ b/database/seeders/SkillCategorySeeder.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\SkillCategory;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class SkillCategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        SkillCategory::create([
+            'category'   => 'Languages',
+            'sort_order' => 1,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Frameworks',
+            'sort_order' => 2,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Databases',
+            'sort_order' => 3,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Version Control',
+            'sort_order' => 4,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Deployment',
+            'sort_order' => 5,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Testing & Debugging',
+            'sort_order' => 6,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Project Management',
+            'sort_order' => 7,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Tools & Technologies',
+            'sort_order' => 8,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Libraries',
+            'sort_order' => 9,
+        ]);
+
+        SkillCategory::create([
+            'category'   => 'Packages',
+            'sort_order' => 10,
+        ]);
+    }
+}

--- a/database/seeders/SkillSeeder.php
+++ b/database/seeders/SkillSeeder.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Skill;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class SkillSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Skill::create([
+            'skill'             => 'PHP',
+            'type'              => 'Primary',
+            'skill_category_id' => 1,
+            'sort_order'        => 1,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'HTML',
+            'type'              => 'Secondary',
+            'skill_category_id' => 1,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'CSS',
+            'type'              => 'Tertiary',
+            'skill_category_id' => 1,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'JavaScript',
+            'type'              => 'Secondary',
+            'skill_category_id' => 1,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Laravel',
+            'type'              => 'Primary',
+            'skill_category_id' => 2,
+            'sort_order'        => 2,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Vue.js',
+            'type'              => 'Tertiary',
+            'skill_category_id' => 2,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Tailwind CSS',
+            'type'              => 'Secondary',
+            'skill_category_id' => 2,
+            'sort_order'        => 4,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'MySQL',
+            'type'              => 'Primary',
+            'skill_category_id' => 3,
+            'sort_order'        => 3,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'PostgreSQL',
+            'type'              => 'Secondary',
+            'skill_category_id' => 3,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Git',
+            'type'              => null,
+            'skill_category_id' => 4,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Mercurial',
+            'type'              => null,
+            'skill_category_id' => 4,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Laravel Forge',
+            'type'              => 'Secondary',
+            'skill_category_id' => 5,
+            'sort_order'        => 5,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Jira',
+            'type'              => 'Primary',
+            'skill_category_id' => 7,
+            'sort_order'        => 6,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Trello',
+            'type'              => null,
+            'skill_category_id' => 7,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+
+        Skill::create([
+            'skill'             => 'MySQL Workbench',
+            'type'              => 'Secondary',
+            'skill_category_id' => 8,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'pgAdmin',
+            'type'              => 'Tertiary',
+            'skill_category_id' => 8,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'PhpStorm',
+            'type'              => 'Secondary',
+            'skill_category_id' => 8,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'Sourcetree',
+            'type'              => 'Secondary',
+            'skill_category_id' => 8,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+
+        Skill::create([
+            'skill'             => 'GitHub',
+            'type'              => 'Secondary',
+            'skill_category_id' => 8,
+            'sort_order'        => null,
+            'show_on_homepage'  => true,
+        ]);
+    }
+}


### PR DESCRIPTION
# [RM-28] | Seed the skills and skill categories tables

- Epic: [RM-14]

## Work
Create seeders for the skills and skill categories tables.

In addition the following changes should be made to the tables:
- `skill_categories`
    - Make `description` nullable
    - Make `pill_class` nullable
    - Add `sort_order`
- `skills`
    - Make `skill_category_id` nullable
    - Add `type`
    - Add `sort_order`
    - Add `show_on_homepage`

## Testing

### Acceptance Criteria 1
**WHEN** I run `php artisan db:seed --class=SkillSeeder`
**THEN** the `skills` table is populated within the database.

### Acceptance Criteria 2
**WHEN** I `run php artisan db:seed --class=SkillCategorySeeder`
**THEN** the `skill_categories` table is populated within the database.

### Acceptance Criteria 3
**WHEN** I create an instance of the `skill` model
**AND** I populate all of the fields (including the new fields)
**THEN** a row is populated in the database.

### Acceptance Criteria 4
**WHEN** I create an instance of the `skill_categories` model
**AND** I populate all of the fields (including the new fields)
**THEN** a row is populated in the database.

[RM-28]: https://rheannemcintosh.atlassian.net/browse/RM-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-14]: https://rheannemcintosh.atlassian.net/browse/RM-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ