### PR TITLE
RM-31 | Create a Standard Layout

### DIFF
--- a/resources/js/Layouts/StandardLayout.vue
+++ b/resources/js/Layouts/StandardLayout.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+
+    // Import the relevant Components
+    import Navigation from "@/Components/Unique/Navigation.vue";
+    import Footer from "@/Layouts/Components/Footer.vue";
+
+</script>
+
+<template>
+
+    <body class="bg-green-900">
+
+        <div class="min-h-screen flex flex-col ">
+
+            <!-- Navigation -->
+            <Navigation />
+
+            <slot />
+
+        </div>
+
+        <!-- Footer -->
+        <Footer :show-privacy-policy="false" :show-c-v="false" />
+
+    </body>
+    
+</template>

--- a/resources/js/Pages/CV/Index.vue
+++ b/resources/js/Pages/CV/Index.vue
@@ -5,6 +5,7 @@ import Pill from "@/Components/Unique/Pill.vue";
 import Education from "@/Pages/Education/Index.vue";
 import Employers from "@/Pages/Employers/Index.vue";
 import Navigation from "@/Components/Unique/Navigation.vue";
+import StandardLayout from "@/Layouts/StandardLayout.vue";
 
 const props = defineProps<{
     degrees: Degree[];
@@ -20,19 +21,20 @@ const handlePillClick = (pillName: string) => {
 </script>
 
 <template>
-    <Navigation />
-    <div class="m-4 max-w-3xl mx-auto">
-        <div class="my-8">
-            <pill name="All" pillColour="green-pill" @pill-click="handlePillClick"/>
-            <pill name="Employers" pillColour="green-pill" @pill-click="handlePillClick"/>
-            <pill name="Education" pillColour="green-pill" @pill-click="handlePillClick"/>
-        </div>
+    <StandardLayout>
+        <div class="m-4 max-w-3xl mx-auto">
+            <div class="my-8">
+                <pill name="All" pillColour="green-pill" @pill-click="handlePillClick"/>
+                <pill name="Employers" pillColour="green-pill" @pill-click="handlePillClick"/>
+                <pill name="Education" pillColour="green-pill" @pill-click="handlePillClick"/>
+            </div>
 
-        <div class="content">
-            <Employers v-if="selectedPill === 'All' || selectedPill === 'Employers'" :employers="props.employers" />
-            <Education v-if="selectedPill === 'All' || selectedPill === 'Education'" :degrees="props.degrees" />
+            <div class="content">
+                <Employers v-if="selectedPill === 'All' || selectedPill === 'Employers'" :employers="props.employers" />
+                <Education v-if="selectedPill === 'All' || selectedPill === 'Education'" :degrees="props.degrees" />
+            </div>
         </div>
-    </div>
+    </StandardLayout>
 </template>
 
 <style scoped>

--- a/resources/js/Pages/Home/Index.vue
+++ b/resources/js/Pages/Home/Index.vue
@@ -2,13 +2,11 @@
 
 import Navigation from "@/Components/Unique/Navigation.vue";
 import SkillPill from "@/Pages/Home/Components/Skill-Pill.vue";
+import StandardLayout from "@/Layouts/StandardLayout.vue";
 </script>
 
 <template>
-    <div class="min-h-screen flex flex-col">
-        <!-- Navigation -->
-        <Navigation/>
-
+    <StandardLayout>
         <!-- Central Component -->
         <div class="flex-grow flex items-center justify-center bg-green-900">
             <div class="m-8 p-2 max-w-screen-lg">
@@ -70,6 +68,5 @@ import SkillPill from "@/Pages/Home/Components/Skill-Pill.vue";
                 </div>
             </div>
         </div>
-    </div>
-
+    </StandardLayout>
 </template>

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -17,7 +17,5 @@
         @inertiaHead
 
     </head>
-    <body class="font-sans antialiased bg-gray-50">
-        @inertia
-    </body>
+    @inertia
 </html>


### PR DESCRIPTION
# [RM-31] | Create a Standard Layout
- Epic: [RM-44]

## Work
Create standard layout which contains the navigation and the footer elements.

Additionally add the standard layout to the home and cv pages.

## Testing

### Acceptance Criteria 1
**WHEN** I view any page
**THEN** the navigation and footer are displayed.

[RM-31]: https://rheannemcintosh.atlassian.net/browse/RM-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-44]: https://rheannemcintosh.atlassian.net/browse/RM-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ