### PR TITLE
RM-32 | Create an About component

### DIFF
--- a/app/Http/Controllers/CVController.php
+++ b/app/Http/Controllers/CVController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Degree;
 use App\Models\Education;
 use App\Models\Employer;
+use App\Models\ProfessionalSummary;
 use Inertia\Inertia;
 
 class CVController extends Controller
@@ -17,8 +18,9 @@ class CVController extends Controller
     public function index()
     {
         return Inertia::render('CV/Index', [
-            'degrees'   => Degree::where('show_on_cv', true)->orderBy('sort_order', 'DESC')->get(),
-            'employers' => $this->getEmployers(),
+            'degrees'                => Degree::where('show_on_cv', true)->orderBy('sort_order', 'DESC')->get(),
+            'employers'              => $this->getEmployers(),
+            'professional_summaries' => ProfessionalSummary::first(),
         ]);
     }
 

--- a/app/Models/ProfessionalSummary.php
+++ b/app/Models/ProfessionalSummary.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ProfessionalSummary extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'professional_summary_text'
+    ];
+}

--- a/database/migrations/2024_10_12_225808_create_professional_summaries_table.php
+++ b/database/migrations/2024_10_12_225808_create_professional_summaries_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('professional_summaries', function (Blueprint $table) {
+            $table->id();
+            $table->text('professional_summary_text');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('professional_summaries');
+    }
+};

--- a/resources/js/Pages/CV/Components/About.vue
+++ b/resources/js/Pages/CV/Components/About.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+
+import CVHeading from "@/Components/CVHeading.vue";
+import {Degree} from "@/types/Degree";
+import {ProfessionalSummary} from "@/types/ProfessionalSummary";
+
+const props = defineProps<{
+    professional_summaries?: ProfessionalSummary;
+}>();
+</script>
+
+<template>
+    <!-- Experience Card -->
+    <div class="bg-white rounded-md shadow-2xl p-8 mb-8">
+        <!-- Experience Heading -->
+        <CVHeading title="About" icon="person" />
+
+        <!-- Experience Content -->
+        <div class="mt-4">
+            <p>
+                {{ props.professional_summaries?.professional_summary_text }}
+            </p>
+        </div>
+    </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/resources/js/Pages/CV/Index.vue
+++ b/resources/js/Pages/CV/Index.vue
@@ -4,10 +4,12 @@ import { ref } from 'vue';
 import Pill from "@/Components/Unique/Pill.vue";
 import Education from "@/Pages/Education/Index.vue";
 import Employers from "@/Pages/Employers/Index.vue";
+import About from "@/Pages/CV/Components/About.vue";
 import Navigation from "@/Components/Unique/Navigation.vue";
 import StandardLayout from "@/Layouts/StandardLayout.vue";
 
 const props = defineProps<{
+    professional_summaries?: ProfessionalSummary;
     degrees: Degree[];
     employers: Employer[];
 }>();
@@ -25,11 +27,13 @@ const handlePillClick = (pillName: string) => {
         <div class="m-4 max-w-3xl mx-auto">
             <div class="my-8">
                 <pill name="All" pillColour="green-pill" @pill-click="handlePillClick"/>
+                <pill name="About" pillColour="green-pill" @pill-click="handlePillClick"/>
                 <pill name="Employers" pillColour="green-pill" @pill-click="handlePillClick"/>
                 <pill name="Education" pillColour="green-pill" @pill-click="handlePillClick"/>
             </div>
 
             <div class="content">
+                <About v-if="selectedPill === 'All' || selectedPill === 'About'" :professional_summaries="props.professional_summaries" />
                 <Employers v-if="selectedPill === 'All' || selectedPill === 'Employers'" :employers="props.employers" />
                 <Education v-if="selectedPill === 'All' || selectedPill === 'Education'" :degrees="props.degrees" />
             </div>

--- a/resources/js/types/ProfessionalSummary.ts
+++ b/resources/js/types/ProfessionalSummary.ts
@@ -1,0 +1,3 @@
+export interface ProfessionalSummary {
+    professional_summary_text: string;
+}


### PR DESCRIPTION
# [RM-32] | Create an About Component
- Epic: [RM-13]

## Work
Create an about component which displays a professional summary. This should fall under the about section and the all section on the CV.

## Testing

### Acceptance Criteria 1
**WHEN** I run `php artisan migrate`
**THEN** a professional summaries table is created.

### Acceptance Criteria 2
**WHEN** I create an instance of the professional summary model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

### Acceptance Criteria 3
**WHEN**  I access the CV and click the “About” button
**THEN** I can see the professional summary on the “About” card.

### Acceptance Criteria 4
**WHEN** I access the CV and click the “All” button
**THEN** I can see the professional summary on the “About” card above the education and experience cards.

[RM-32]: https://rheannemcintosh.atlassian.net/browse/RM-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-13]: https://rheannemcintosh.atlassian.net/browse/RM-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ