### PR TITLE
RM-43 | Generate a Colour Scheme

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,11 @@ export default {
             fontFamily: {
                 sans: ['Figtree', ...defaultTheme.fontFamily.sans],
             },
+            colors: {
+                rmLight:  '#F6F7F2',
+                rmDark:   '#011A0B',
+                rmAccent: '#65A30D',
+            }
         },
     },
 


### PR DESCRIPTION
# [RM-43] | Generate a Colour Scheme
- Epic: [RM-44]

## Work
To allow for consistent styling throughout the platform, three custom colours should be added to the tailwind config. These should be kept generic so they can be easily updated in the future with different colours.

## Testing

- Create three divs with set heights and weights, and assign background colours, text colours or border colours to one of the following:
    - `rmLight`
    - `rmDark`
    - `rmAccent`

### Acceptance Criteria 1
**WHEN** I attempt to use the three new tailwind colours in a component
**THEN** the colours work correctly (i.e. they can be used as a background, border or text colour)

[RM-43]: https://rheannemcintosh.atlassian.net/browse/RM-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-44]: https://rheannemcintosh.atlassian.net/browse/RM-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ