### PR TITLE
RM-45 | Create the Page Heading Component

### DIFF
--- a/resources/js/Components/Headings/PageHeading.vue
+++ b/resources/js/Components/Headings/PageHeading.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+
+    // Import the relevant types
+    import { PageHeading } from "@/types/Headings/PageHeading";
+
+    // Define the props
+    const props = defineProps<PageHeading>();
+
+</script>
+
+<template>
+
+    <h1>{{ props.title }}</h1>
+
+</template>
+
+<style scoped lang="postcss">
+
+    h1 {
+        @apply text-rmLight text-5xl font-bold my-8;
+    }
+
+</style>

--- a/resources/js/Pages/CV/Index.vue
+++ b/resources/js/Pages/CV/Index.vue
@@ -29,6 +29,7 @@ const handlePillClick = (pillName: string) => {
         <div class="m-4 max-w-3xl mx-auto">
             <div class="my-8">
                 <pill name="All" pillColour="green-pill" @pill-click="handlePillClick"/>
+            <PageHeading title="CV" />
                 <pill name="About" pillColour="green-pill" @pill-click="handlePillClick"/>
                 <pill name="Employers" pillColour="green-pill" @pill-click="handlePillClick"/>
                 <pill name="Education" pillColour="green-pill" @pill-click="handlePillClick"/>

--- a/resources/js/types/Headings/PageHeading.ts
+++ b/resources/js/types/Headings/PageHeading.ts
@@ -1,0 +1,3 @@
+export interface PageHeading {
+    title: string;
+}


### PR DESCRIPTION
# [RM-45] | Create the Page Heading Component
- Epic: [RM-62]

## Work
Create a page heading component which takes a title as a prop.

## Testing

### Acceptance Criteria 1
**WHEN** I view a page which has a page heading component
**THEN** a heading is displayed with the passed in title.

[RM-30]: https://rheannemcintosh.atlassian.net/browse/RM-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-62]: https://rheannemcintosh.atlassian.net/browse/RM-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-45]: https://rheannemcintosh.atlassian.net/browse/RM-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ