### PR TITLE
RM-49 | Update the Standard Layout to use a dark background

### DIFF
--- a/resources/js/Layouts/StandardLayout.vue
+++ b/resources/js/Layouts/StandardLayout.vue
@@ -8,7 +8,7 @@
 
 <template>
 
-    <body class="bg-green-900">
+    <body>
 
         <div class="min-h-screen flex flex-col ">
 
@@ -23,5 +23,13 @@
         <Footer :show-privacy-policy="false" :show-c-v="false" />
 
     </body>
-    
+
 </template>
+
+<style scoped lang="postcss">
+
+    body {
+        @apply bg-rmDark;
+    }
+
+</style>


### PR DESCRIPTION
# [RM-49] | Update the Standard Layout to use a dark background

## Work
Change the background to use `bg-rmDark`. Ideally extract the style classes into a scope postcss tag.

## Testing

### Acceptance Criteria 1
**WHEN** I visit a page which uses the Standard Layout
**THEN** the background is coloured in the custom dark green.

[RM-43]: https://rheannemcintosh.atlassian.net/browse/RM-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[RM-49]: https://rheannemcintosh.atlassian.net/browse/RM-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ