### PR TITLE
RM-51 | Update the Navigation Component to Use the New Colour Scheme

### DIFF
--- a/resources/js/Components/Unique/Navigation.vue
+++ b/resources/js/Components/Unique/Navigation.vue
@@ -11,24 +11,24 @@
 
 <template>
     <nav>
-        <div id="navigation" class="bg-green-800 p-8 xl:px-20">
+        <div id="navigation" class="bg-rmDark p-8 xl:px-20">
             <div class="flex items-center justify-between h-20">
 
                 <!-- Logo -->
                 <div id="logo" class="flex">
-                    <span class="material-symbols-rounded text-7xl text-gray-50 items-center">
+                    <span class="material-symbols-rounded text-7xl text-rmLight items-center">
                         support_agent
                     </span>
                 </div>
 
                 <!-- Navigation Links for Desktop -->
-                <div id="navigation-links" class="hidden md:flex md:space-x-12 md:text-gray-50 md:text-bold">
+                <div id="navigation-links" class="hidden md:flex md:space-x-12 md:text-rmLight md:text-bold">
                     <NavigationLinks />
                 </div>
 
                 <!-- Burger Icon for Mobile -->
                 <div id="burger-icon" class="md:hidden flex">
-                    <span class="material-symbols-rounded text-4xl text-gray-50 cursor-pointer" @click="toggleMobileMenu">
+                    <span class="material-symbols-rounded text-4xl text-rmLight cursor-pointer" @click="toggleMobileMenu">
                         menu
                     </span>
                 </div>
@@ -37,8 +37,8 @@
         </div>
 
         <!-- Navigation Links for Mobile -->
-        <div v-if="isMobileMenuVisible" id="mobile-menu" class="bg-pink-500">
-            <div class="bg-green-900 text-gray-50 p-4">
+        <div v-if="isMobileMenuVisible" id="mobile-menu">
+            <div class="bg-rmDark text-rmLight p-4">
                 <div class="space-y-4">
                     <NavigationLinks />
                 </div>

--- a/resources/js/Components/Unique/NavigationLink.vue
+++ b/resources/js/Components/Unique/NavigationLink.vue
@@ -9,8 +9,8 @@
 
     const classes = computed(() =>
         props.active
-            ? 'bg-green-900 hover:bg-green-950 rounded-xl px-4 py-1 cursor-pointer m-2 w-24 text-center'
-            : 'hover:bg-green-950 rounded-xl px-4 py-1 cursor-pointer m-2 w-24 text-center'
+            ? 'rounded-xl px-4 py-1 cursor-pointer m-2 w-24 text-center text-rmAccent font-bold bg-rmAccent/10'
+            : 'hover:bg-rmAccent/10 rounded-xl px-4 py-1 cursor-pointer m-2 w-24 text-center'
     );
 </script>
 


### PR DESCRIPTION
# [RM-51] | Update the Navigation Component to Use the New Colour Scheme
- Epic: [RM-44]

## Work
The navigation component still used the old colour scheme. This updates the colour scheme to use the new colours.

## Testing

### Acceptance Criteria 1
**WHEN** I look at the navigation
**THEN** the background and text colour uses the new colour scheme

[RM-51]: https://rheannemcintosh.atlassian.net/browse/RM-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-44]: https://rheannemcintosh.atlassian.net/browse/RM-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ