### PR TITLE
RM-52 | Update Components to use the New Colour Scheme

### DIFF
--- a/resources/js/Components/CVHeading.vue
+++ b/resources/js/Components/CVHeading.vue
@@ -7,11 +7,11 @@
 </script>
 
 <template>
-    <div class="flex items-center text-green-700 ">
-            <span class="material-symbols-rounded text-4xl">
+    <div class="flex items-center text-rmLight ">
+            <span class="material-symbols-rounded text-3xl text-rmAccent">
                 {{ icon }}
             </span>
-        <h1 class="pl-2 font-bold text-4xl">
+        <h1 class="pl-2 font-bold text-3xl">
             {{ title }}
         </h1>
     </div>

--- a/resources/js/Components/Cards/Card.vue
+++ b/resources/js/Components/Cards/Card.vue
@@ -13,7 +13,7 @@
 <style scoped lang="postcss">
 
     div {
-        @apply bg-rmLight/10 rounded-md shadow-2xl p-8 mb-8;
+        @apply bg-rmLight/5 rounded-md shadow-2xl p-8 mb-8;
     }
 
 </style>


### PR DESCRIPTION
# [RM-52] | Update Components to use the New Colour Scheme
- Epic: [RM-44]

## Work
The CV heading and card components still used the old colour scheme. This updates the colour scheme to use the new colours.

## Testing

### Acceptance Criteria 1
**WHEN** I look at the cards
**THEN** the background colour uses the new colour scheme

### Acceptance Criteria 1
**WHEN** I look at the cv heading
**THEN** the text colour uses the new colour scheme

[RM-52]: https://rheannemcintosh.atlassian.net/browse/RM-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-44]: https://rheannemcintosh.atlassian.net/browse/RM-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ