### PR TITLE
RM-61 | Create a Page migration and model

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Page extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'slug',
+        'active',
+        'sort_order',
+    ];
+}

--- a/database/migrations/2024_10_16_213939_create_pages_table.php
+++ b/database/migrations/2024_10_16_213939_create_pages_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->string('slug')->unique();
+            $table->boolean('active')->default(false);
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('pages');
+    }
+};


### PR DESCRIPTION
# [RM-61] | Create a `Page` migration and model
- Epic: [RM-11]

## Work
Create a `Page` model and migration to store various responsibilities. In order to turn pages on and off easily, it is best to store these in a database table. This should allow for the page name, slug and state to be stored.

## Testing
- Run `php artisan migrate`

### Acceptance Criteria 1 
**WHEN** I have ran the migration
**THEN** a `page` table is created within the database.

### Acceptance Criteria 2
**WHEN** I create an instance of the `page` model
**AND** I populate all of the fields
**THEN** a row is populated in the database.

[RM-61]: https://rheannemcintosh.atlassian.net/browse/RM-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ