### PR TITLE
RM-63 | Pass the Page Information to the Navigation

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Page;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Tighten\Ziggy\Ziggy;
@@ -39,6 +40,9 @@ class HandleInertiaRequests extends Middleware
                 ...(new Ziggy())->toArray(),
                 'location' => $request->url(),
             ],
+            'pages' => Page::where('active', true)
+                ->orderBy('sort_order')
+                ->get()
         ];
     }
 }

--- a/resources/js/Components/Unique/NavigationLinks.vue
+++ b/resources/js/Components/Unique/NavigationLinks.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
     import NavigationLink from "@/Components/Unique/NavigationLink.vue";
+    import { usePage } from '@inertiajs/vue3';
+    import { computed } from 'vue';
+
+    const page = usePage();
+    const pages = computed(() => page.props.pages);
 </script>
 
 <template>
+
     <NavigationLink :href="route('home')" :active="route().current('home')">Home</NavigationLink>
-    <NavigationLink :href="route('cv')" :active="route().current('cv')">CV</NavigationLink>
-<!--    <NavigationLink :href="route('skills')" :active="route().current('skills')">Skills</NavigationLink>-->
-<!--    <NavigationLink :href="route('timeline')" :active="route().current('timeline')">Timeline</NavigationLink>-->
-<!--    <NavigationLink :href="route('contact')" :active="route().current('contact')">Contact</NavigationLink>-->
+    <div v-for="page in pages" :key="page.id">
+        <NavigationLink :href="route(page.slug)" :active="route().current(page.slug)">{{ page.title }}</NavigationLink>
+    </div>
+
 </template>
 
 <style scoped>


### PR DESCRIPTION
# [RM-63] | Pass the Page Information to the Navigation
- Epic: [RM-64]

## Work
Currently the navigation is hardcoded. This takes the new page table and loops through the additional pages.

## Testing

### Acceptance Criteria 1 
**WHEN** I make a page active
**THEN** it displays in the navigation bar

### Acceptance Criteria 2
**WHEN** I make a page inactive
**THEN** it does not display in the navigation bar

[RM-63]: https://rheannemcintosh.atlassian.net/browse/RM-63?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-64]: https://rheannemcintosh.atlassian.net/browse/RM-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ