### PR TITLE
RM-67 | Create the Learning Platforms Migration, Model & Seeder

### DIFF
--- a/app/Models/LearningPlatform.php
+++ b/app/Models/LearningPlatform.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LearningPlatform extends Model
+{
+    protected $fillable = [
+        'name',
+        'url',
+    ];
+}

--- a/database/migrations/2024_10_18_153448_create_learning_platforms_table.php
+++ b/database/migrations/2024_10_18_153448_create_learning_platforms_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('learning_platforms', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('url');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('learning_platforms');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -35,6 +35,7 @@ class DatabaseSeeder extends Seeder
             PageSeeder::class,
             SkillCategorySeeder::class,
             SkillSeeder::class,
+            LearningPlatformSeeder::class,
         ]);
 
         foreach ($this->customSeeders as $file => $seederClass) {

--- a/database/seeders/LearningPlatformSeeder.php
+++ b/database/seeders/LearningPlatformSeeder.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\LearningPlatform;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class LearningPlatformSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $platforms = [
+            [
+                'name' => 'Coursera',
+                'url'  => 'https://www.coursera.org/'
+            ],
+            [
+                'name' => 'Laracasts',
+                'url'  => 'https://laracasts.com/'
+            ],
+            [
+                'name' => 'Atlassian University',
+                'url'  => 'https://university.atlassian.com/'
+            ],
+            [
+                'name' => 'Codecademy',
+                'url'  => 'https://www.codecademy.com/'
+            ],
+            [
+                'name' => 'Treehouse',
+                'url'  => 'https://teamtreehouse.com/'
+            ],
+            [
+                'name' => 'edX',
+                'url'  => 'https://www.edx.org/'
+            ],
+            [
+                'name' => 'FutureLearn',
+                'url'  => 'https://www.futurelearn.com/'
+            ],
+            [
+                'name' => 'Khan Academy',
+                'url'  => 'https://www.khanacademy.org/'
+            ],
+            [
+                'name' => 'LinkedIn Learning',
+                'url'  => 'https://www.linkedin.com/learning/'
+            ],
+            [
+                'name' => 'Udacity',
+                'url'  => 'https://www.udacity.com/'
+            ],
+            [
+                'name' => 'Udemy',
+                'url'  => 'https://www.udemy.com/'
+            ],
+        ];
+
+        foreach ($platforms as $platform) {
+            LearningPlatform::create($platform);
+        }
+    }
+}


### PR DESCRIPTION
# [RM-67] | Create the Learning Platforms Migration, Model & Seeder

- Epic: [RM-11]

## Work
Create a `Learning Platform` model, migration and seeder to store various learning platforms which offer courses. The seeder populates some of the regular tech based sites for learning.

## Testing
- Run `php artisan migrate`
- Run `php artisan db:seed --class=LearningPlatformSeeder`

### Acceptance Criteria 1
**WHEN** I have ran the migration
**THEN** a `learning-platforms` table is created within the database

### Acceptance Criteria 2
**WHEN** I create an instance of the Learning Platform model
**AND** I populate all of the fields
**THEN** there a row is populated in the database

### Acceptance Criteria 3
**WHEN** I run `php artisan db:seed`
**THEN** multiple learning platform rows are populated in the database.

[RM-67]: https://rheannemcintosh.atlassian.net/browse/RM-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ