### PR TITLE
RM-68 | Create the Course Mode, Migration and Seeder

### DIFF
--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Course extends Model
+{
+    protected $fillable = [
+        'title',
+        'learning_platform_id',
+        'started_at',
+        'completed_at',
+        'url',
+    ];
+}

--- a/database/migrations/2024_10_19_133208_create_courses_table.php
+++ b/database/migrations/2024_10_19_133208_create_courses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('courses', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->foreignId('learning_platform_id')->nullable()->constrained()->onDelete('cascade');
+            $table->dateTime('started_at')->nullable();
+            $table->dateTime('completed_at')->nullable();
+            $table->string('url')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('courses');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use Database\Seeders\custom\AboutSeeder;
+use Database\Seeders\custom\CourseSeeder;
 use Database\Seeders\custom\DegreeSeeder;
 use Database\Seeders\custom\EducationSeeder;
 use Database\Seeders\custom\EmployerSeeder;
@@ -24,6 +25,7 @@ class DatabaseSeeder extends Seeder
         'database/seeders/custom/EmployerSeeder.php'       => EmployerSeeder::class,
         'database/seeders/custom/RoleSeeder.php'           => RoleSeeder::class,
         'database/seeders/custom/ResponsibilitySeeder.php' => ResponsibilitySeeder::class,
+        'database/seeders/custom/CourseSeeder.php'         => CourseSeeder::class,
     ];
 
     /**


### PR DESCRIPTION
# [RM-68] | Create the Course Migration, Model & Seeder

- Epic: [RM-11]

## Work
Create a `Course` model, migration and seeder to store various courses.

## Testing
- Run `php artisan migrate`
- Run `php artisan db:seed --class=CourseSeeder`

### Acceptance Criteria 1
**WHEN** I have ran the migration
**THEN** a `courses` table is created within the database

### Acceptance Criteria 2
**WHEN** I create an instance of the Course model
**AND** I populate all of the fields
**THEN** there a row is populated in the database

### Acceptance Criteria 3
**WHEN** I run `php artisan db:seed`
**AND** a Course seeder exists
**THEN** the courses are populated in the database.

[RM-68]: https://rheannemcintosh.atlassian.net/browse/RM-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ