### PR TITLE
RM-69 | Create the Lesson Migration, Model & Seeder

### DIFF
--- a/app/Models/Lesson.php
+++ b/app/Models/Lesson.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Lesson extends Model
+{
+    protected $fillable = [
+        'title',
+        'completed_at',
+        'course_id',
+        'number',
+        'section',
+    ];
+}

--- a/database/migrations/2024_10_19_191551_create_lessons_table.php
+++ b/database/migrations/2024_10_19_191551_create_lessons_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('lessons', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->foreignId('course_id')->nullable()->constrained()->onDelete('cascade');
+            $table->timestamp('completed_at')->nullable();
+            $table->integer('number')->nullable();
+            $table->string('section')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('lessons');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -7,6 +7,7 @@ use Database\Seeders\custom\CourseSeeder;
 use Database\Seeders\custom\DegreeSeeder;
 use Database\Seeders\custom\EducationSeeder;
 use Database\Seeders\custom\EmployerSeeder;
+use Database\Seeders\custom\LessonSeeder;
 use Database\Seeders\custom\ResponsibilitySeeder;
 use Database\Seeders\custom\RoleSeeder;
 use Illuminate\Database\Seeder;
@@ -26,6 +27,7 @@ class DatabaseSeeder extends Seeder
         'database/seeders/custom/RoleSeeder.php'           => RoleSeeder::class,
         'database/seeders/custom/ResponsibilitySeeder.php' => ResponsibilitySeeder::class,
         'database/seeders/custom/CourseSeeder.php'         => CourseSeeder::class,
+        'database/seeders/custom/LessonSeeder.php'         => LessonSeeder::class,
     ];
 
     /**


### PR DESCRIPTION
# [RM-69] | Create the Lesson Migration, Model & Seeder

- Epic: [RM-11]

## Work
Create a `Lesson` model, migration and seeder to store various courses.

## Testing
- Run `php artisan migrate`
- Run `php artisan db:seed --class=LessonSeeder`

### Acceptance Criteria 1
**WHEN** I have ran the migration
**THEN** a `lessons` table is created within the database

### Acceptance Criteria 2
**WHEN** I create an instance of the Lesson model
**AND** I populate all of the fields
**THEN** there a row is populated in the database

### Acceptance Criteria 3
**WHEN** I run `php artisan db:seed`
**AND** a Lesson seeder exists
**THEN** the lessons are populated in the database.

[RM-69]: https://rheannemcintosh.atlassian.net/browse/RM-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-11]: https://rheannemcintosh.atlassian.net/browse/RM-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ