### PR TITLE
RM-54 | Create a Page Layout Component

### DIFF
--- a/resources/js/Layouts/PageLayout.vue
+++ b/resources/js/Layouts/PageLayout.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+    import StandardLayout from "@/Layouts/StandardLayout.vue";
+    import PageHeading from "@/Components/Headings/PageHeading.vue";
+    import PageIntroduction from "@/Components/Text/PageIntroduction.vue";
+    import Link from "@/Components/Link/Link.vue";
+
+    defineProps<{
+        title: string;
+        pageIntroduction: string;
+    }>();
+</script>
+
+<template>
+    <StandardLayout>
+        <div class="m-4 max-w-3xl mx-auto">
+            <PageHeading :title="title" />
+
+            <PageIntroduction>
+                {{ pageIntroduction }}
+                <Link url="/" text="You can download a copy of my latest CV here!"/>
+            </PageIntroduction>
+            <slot />
+        </div>
+    </StandardLayout>
+</template>
+
+<style scoped lang="postcss">
+
+body {
+    @apply bg-rmDark;
+}
+
+</style>
+

--- a/resources/js/Pages/CV/Index.vue
+++ b/resources/js/Pages/CV/Index.vue
@@ -5,9 +5,9 @@ import Pill from "@/Components/Unique/Pill.vue";
 import Education from "@/Pages/Education/Index.vue";
 import Employers from "@/Pages/Employers/Index.vue";
 import About from "@/Pages/CV/Components/About.vue";
-import Navigation from "@/Components/Unique/Navigation.vue";
-import StandardLayout from "@/Layouts/StandardLayout.vue";
 import {Skill} from "@/types/Skill";
+import PageLayout from "@/Layouts/PageLayout.vue";
+
 
 const props = defineProps<{
     professional_summaries?: ProfessionalSummary;
@@ -25,15 +25,11 @@ const handlePillClick = (pillName: string) => {
 </script>
 
 <template>
-    <StandardLayout>
-        <div class="m-4 max-w-3xl mx-auto">
-            <div class="my-8">
-            <PageHeading title="CV" />
-
-            <PageIntroduction>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut sem nec justo pretium gravida. Vivamus diam lorem, accumsan ac laoreet quis, tristique ac ex. Curabitur egestas nisl velit, facilisis ornare metus vulputate non. In hac habitasse platea dictumst.
-                <Link url="/" text="You can download a copy of my latest CV here!"/>
-            </PageIntroduction>
+    <PageLayout
+        title="RHEANNE"
+        pageIntroduction="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ut sem nec justo pretium gravida. Vivamus diam lorem, accumsan ac laoreet quis, tristique ac ex. Curabitur egestas nisl velit, facilisis ornare metus vulputate non. In hac habitasse platea dictumst."
+    >
+            <div class="my-6">
                 <pill name="All" pillColour="selected-pill" @pill-click="handlePillClick"/>
                 <pill name="About" pillColour="secondary-pill" @pill-click="handlePillClick"/>
                 <pill name="Employers" pillColour="secondary-pill" @pill-click="handlePillClick"/>
@@ -45,8 +41,7 @@ const handlePillClick = (pillName: string) => {
                 <Employers v-if="selectedPill === 'All' || selectedPill === 'Employers'" :employers="props.employers" :skills="props.skills" />
                 <Education v-if="selectedPill === 'All' || selectedPill === 'Education'" :degrees="props.degrees" />
             </div>
-        </div>
-    </StandardLayout>
+    </PageLayout>
 </template>
 
 <style scoped>


### PR DESCRIPTION
# [RM-54] | Create a Page Layout Component

- Epic: [RM-62]

## Work
Create a page layout component which allows for the majority of components to be laid out the same. This should take in the page title and description.

## Testing

### Acceptance Criteria 1
**WHEN** I access a page which uses the page layout component
**THEN** all the page looks the same as before, and displays the heading and introduction

[RM-54]: https://rheannemcintosh.atlassian.net/browse/RM-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RM-62]: https://rheannemcintosh.atlassian.net/browse/RM-62?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ